### PR TITLE
Add only deform bones option

### DIFF
--- a/Asset_Creation_Toolset_2023_2_Bl400/import_export_tools.py
+++ b/Asset_Creation_Toolset_2023_2_Bl400/import_export_tools.py
@@ -709,6 +709,10 @@ class VIEW3D_PT_Import_Export_Tools_Panel(bpy.types.Panel):
 						row.prop(act, "export_tangent_space", text="")
 
 						row = box.row(align=True)
+						row.label(text=" Only Deform Bones")
+						row.prop(act, "export_only_deform_bones", text="")
+
+						row = box.row(align=True)
 						row.label(text=" Add Leaf Bones")
 						row.prop(act, "export_add_leaf_bones", text="")
 

--- a/Asset_Creation_Toolset_2023_2_Bl400/props.py
+++ b/Asset_Creation_Toolset_2023_2_Bl400/props.py
@@ -146,6 +146,11 @@ class ACT_Addon_Props(bpy.types.PropertyGroup):
 		description="Combine Meshes before Export",
 		default=False)
 
+	export_only_deform_bones: BoolProperty(
+		name="Only Deform Bones",
+		description="Only Deform Bones",
+		default=False)
+
 	export_add_leaf_bones: BoolProperty(
 		name="Add Leaf Bones",
 		description="Add Leaf Bones",

--- a/Asset_Creation_Toolset_2023_2_Bl400/utils.py
+++ b/Asset_Creation_Toolset_2023_2_Bl400/utils.py
@@ -83,14 +83,18 @@ def Export_Model(path, name):
 					apply_scale_options='FBX_SCALE_ALL',
 					use_mesh_modifiers=True, mesh_smooth_type=act.export_smoothing,
 					use_mesh_edges=act.export_loose_edges, use_tspace=act.export_tangent_space,
-					add_leaf_bones=act.export_add_leaf_bones, colors_type=act.export_vc_color_space)
+					add_leaf_bones=act.export_add_leaf_bones,
+					use_armature_deform_only=act.export_only_deform_bones,
+					colors_type=act.export_vc_color_space)
 			elif act.export_target_engine == 'UNREAL':
 				bpy.ops.export_scene.fbx(
 					filepath=str(path + name + '.fbx'), use_selection=True,
 					apply_scale_options='FBX_SCALE_NONE',
 					use_mesh_modifiers=True, mesh_smooth_type=act.export_smoothing,
 					use_mesh_edges=act.export_loose_edges, use_tspace=act.export_tangent_space,
-					add_leaf_bones=act.export_add_leaf_bones, colors_type=act.export_vc_color_space)
+					add_leaf_bones=act.export_add_leaf_bones,
+					use_armature_deform_only=act.export_only_deform_bones,
+					colors_type=act.export_vc_color_space)
 			elif act.export_target_engine == 'UNITY2023':
 				bpy.ops.export_scene.fbx(
 					filepath=str(path + name + '.fbx'), use_selection=True,
@@ -98,6 +102,7 @@ def Export_Model(path, name):
 					use_mesh_modifiers=True, mesh_smooth_type=act.export_smoothing,
 					use_mesh_edges=act.export_loose_edges, use_tspace=act.export_tangent_space,
 					global_scale=0.01, axis_forward='Y', axis_up='Z', add_leaf_bones=act.export_add_leaf_bones,
+					use_armature_deform_only=act.export_only_deform_bones,
 					colors_type=act.export_vc_color_space)
 
 		if act.export_format == 'OBJ':


### PR DESCRIPTION
Add "Only Deform Bones" option, same as default FBX exporter.
I think this is necessary to exclude rigs from the asset.